### PR TITLE
Capitalize plugin name

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,4 +1,4 @@
-name: filesource
+name: Filesource
 version: 0.2
 description: "With **filesource** a user can show the source of any text file in a post"
 icon: trello


### PR DESCRIPTION
So it's shown capitalized in the Admin interface as with the other plugins
